### PR TITLE
[FIX] Github URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     # Metadata
     author='Jason Kai',
     author_email='tkai@uwo.ca',
-    url='https://github.com/khanlabs/neurobeer',
+    url='https://github.com/khanlab/neurobeer',
 )


### PR DESCRIPTION
Fix URL found in `setup.py` from `https://github.com/khanlabs/neurobeer/` to `https://github.com/khanlab/neurobeer`